### PR TITLE
Hide files colum on mobile devices

### DIFF
--- a/query.html
+++ b/query.html
@@ -56,6 +56,7 @@
 	data-page-list="[1000, 10000, 100000, All]"
 	data-smart-display="true"
 	data-mobile-responsive="true"
+	data-columns-hidden="['file']"
 	class="hidden">
 
 	<thead>

--- a/query.html
+++ b/query.html
@@ -56,7 +56,7 @@
 	data-page-list="[1000, 10000, 100000, All]"
 	data-smart-display="true"
 	data-mobile-responsive="true"
-	data-columns-hidden="['file']"
+	data-columns-hidden="['3']"
 	class="hidden">
 
 	<thead>


### PR DESCRIPTION
The pull request hides the files column on mobile devices using the bootstrap-table-mobile-extension.